### PR TITLE
Restarting gunicorn workers to free memory

### DIFF
--- a/dalgo-kubernetes/superset-kubernetes/production/dalgo_internal/values5.0.0.yaml
+++ b/dalgo-kubernetes/superset-kubernetes/production/dalgo_internal/values5.0.0.yaml
@@ -608,7 +608,8 @@ supersetNode:
   #   db_user: "test_superset"
   #   db_pass: "test_superset"
   #   db_name: "test_superset"
-  env: {}
+  env:
+    WORKER_MAX_REQUESTS: 500
   # -- If true, forces deployment to reload on each upgrade
   forceReload: false
   # -- Init containers


### PR DESCRIPTION
This was done because noora, peepul, janaagraha etc pods were not releasing the memory and hence leading to pod crashes. 