### PR TITLE
Add Glific URLs to moonshine Superset configuration

### DIFF
--- a/dalgo-kubernetes/dalgo-superset-production-cluster/superset/moonshine/values5.0.0.yaml
+++ b/dalgo-kubernetes/dalgo-superset-production-cluster/superset/moonshine/values5.0.0.yaml
@@ -427,6 +427,8 @@ configOverrides:
                 "http://localhost:3000",
                 "https://staging.dalgo.org",
                 "https://dashboard.dalgo.org",
+                "https://api.glific.test:3000",
+                "https://*.glific.com"
             ],
         },
     }


### PR DESCRIPTION
Add glific urls to whitelist to allow embedding. Whether we use moonshine or our own instance will be decided later, this is currently only used internally. 